### PR TITLE
Verschiedene Verbesserungen an Forms CSS

### DIFF
--- a/css/aguapop/forms.css
+++ b/css/aguapop/forms.css
@@ -57,11 +57,20 @@ padding:2px;
 font-family:inherit;
 font-size:inherit;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right #E9E8FA;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -105,6 +114,7 @@ margin-bottom:7px;
 border: 2px solid #565FA9;
 border-radius: 15px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form input[type="reset"]{
 padding-top: 2px;
@@ -112,10 +122,11 @@ padding-bottom: 2px;
 padding-left: 6px;
 padding-right: 6px;
 margin: 1px;
-border: 1px solid #8DCDEB;
-color:#8DCDEB;
+margin-bottom:7px;
+border: 2px solid #565FA9;
 border-radius: 15px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form .number {
 text-align:right;

--- a/css/arc-dark/forms.css
+++ b/css/arc-dark/forms.css
@@ -54,11 +54,20 @@ padding:2px;
 font-family:inherit;
 font-size:inherit;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right transparent;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 color:white;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -103,6 +112,7 @@ border: 1px solid #8DCDEB;
 color:#8DCDEB;
 border-radius: 15px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form input[type="reset"]{
 background:transparent;
@@ -115,6 +125,7 @@ border: 1px solid #8DCDEB;
 color:#8DCDEB;
 border-radius: 15px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form .number {
 text-align:right;

--- a/css/default/forms.css
+++ b/css/default/forms.css
@@ -54,11 +54,20 @@ color:#1A1A1A;
 font-family:inherit;
 font-size:inherit;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right #C0C3FF;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -106,16 +115,17 @@ cursor: pointer;
 form input[type="submit"]:hover{
 background:#7F7F7F;
 color:black;
+transition-duration:0.5s;
 }
 form input[type="reset"]{
-padding-top: 2px;
-padding-bottom: 2px;
-padding-left: 6px;
-padding-right: 6px;
+padding-top: 6px;
+padding-bottom: 6px;
+padding-left: 16px;
+padding-right: 16px;
 margin: 1px;
-border: 1px solid #8DCDEB;
-color:#8DCDEB;
-border-radius: 15px;
+border: 1px solid #588BB6;
+color:#1A1A1A;
+border-radius: 5px;
 cursor: pointer;
 }
 form .number {

--- a/css/fluid/forms.css
+++ b/css/fluid/forms.css
@@ -49,16 +49,25 @@ form fieldset field input,textarea,select {
 background-color:#556699;
 border-radius: 5px;
 border: 1px solid #8DCDEB;
-padding:4px;
+padding:2px;
 color:#EFEFEF;
 font-family:inherit;
 font-size:inherit;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right #556699;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -103,17 +112,20 @@ color:#070745;
 background:#CAE7F1
 border-radius: 3px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form input[type="reset"]{
-padding-top: 2px;
-padding-bottom: 2px;
-padding-left: 6px;
-padding-right: 6px;
+padding-top: 4px;
+padding-bottom: 4px;
+padding-left: 16px;
+padding-right: 16px;
 margin: 1px;
 border: 1px solid #8DCDEB;
-color:#1A1A1A;
-border-radius: 15px;
+color:#070745;
+background:#CAE7F1
+border-radius: 3px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form .number {
 text-align:right;

--- a/css/fresh/forms.css
+++ b/css/fresh/forms.css
@@ -52,11 +52,20 @@ color:#1A1A1A;
 font-family:inherit;
 font-size:inherit;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right transparent;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -100,17 +109,19 @@ border: 1px solid #8DCDEB;
 color:#1A1A1A;
 border-radius: 5px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form input[type="reset"]{
-padding-top: 2px;
-padding-bottom: 2px;
-padding-left: 6px;
-padding-right: 6px;
+padding-top: 6px;
+padding-bottom: 6px;
+padding-left: 10px;
+padding-right: 10px;
 margin: 1px;
 border: 1px solid #8DCDEB;
 color:#1A1A1A;
-border-radius: 15px;
+border-radius: 5px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form .number {
 text-align:right;

--- a/css/gel/forms.css
+++ b/css/gel/forms.css
@@ -51,11 +51,17 @@ padding:2px;
 font-family:inherit;
 font-size:inherit;
 }
+form fieldset field select {
+background:linear-gradient(#EAE7E7, #939393);
+padding-right:24px;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -100,17 +106,20 @@ border: 1px solid #8DCDEB;
 color:#000000;
 border-radius: 15px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form input[type="reset"]{
-padding-top: 2px;
-padding-bottom: 2px;
+background-image: linear-gradient(#EAE7E7, #939393);
+padding-top: 4px;
+padding-bottom: 4px;
 padding-left: 6px;
 padding-right: 6px;
 margin: 1px;
 border: 1px solid #8DCDEB;
-color:#8DCDEB;
+color:#000000;
 border-radius: 15px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form .number {
 text-align:right;

--- a/css/mobile/forms.css
+++ b/css/mobile/forms.css
@@ -46,6 +46,13 @@ padding:2px;
 font-family:inherit;
 font-size:inherit;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right #e2f5ff;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
 }

--- a/css/professional-rtl/forms.css
+++ b/css/professional-rtl/forms.css
@@ -54,11 +54,20 @@ color:#1A1A1A;
 font-family:inherit;
 font-size:inherit;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right transparent;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -103,6 +112,7 @@ color:#8DCDEB;
 border-radius: 15px;
 cursor: pointer;
 color:#1A1A1A;
+transition-duration:0.5s;
 }
 form input[type="reset"]{
 padding-top: 2px;
@@ -115,6 +125,7 @@ color:#8DCDEB;
 border-radius: 15px;
 cursor: pointer;
 color:#1A1A1A;
+transition-duration:0.5s;
 }
 form .number {
 text-align:right;

--- a/css/professional/forms.css
+++ b/css/professional/forms.css
@@ -55,11 +55,20 @@ font-family:inherit;
 font-size:inherit;
 transition-duration:0.5s;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right #FFFFE0;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -111,15 +120,17 @@ background:linear-gradient(315deg, #655051, #551b1b);
 color:#E6E6FA;
 }
 form input[type="reset"]{
-padding-top: 2px;
-padding-bottom: 2px;
-padding-left: 6px;
-padding-right: 6px;
+background:#EEEEEE;
+padding-top: 5px;
+padding-bottom: 5px;
+padding-left: 16px;
+padding-right: 16px;
 margin: 1px;
-border: 1px solid #8DCDEB;
+border: 1px solid #1A1A1A;
 color:#1A1A1A;
-border-radius: 15px;
+border-radius: 3px;
 cursor: pointer;
+transition-duration:0.5s;
 }
 form .number {
 text-align:right;

--- a/css/silverwolf/forms.css
+++ b/css/silverwolf/forms.css
@@ -53,15 +53,24 @@ font-family:inherit;
 font-size:inherit;
 transition-duration:0.5s;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right transparent;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 background-color:#e3e5f5;
 border-color:gray;
 border-style:solid;
 border-width:1px;
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -111,16 +120,15 @@ background:#7F7F7F;
 color:#FFFFFF;
 }
 form input[type="reset"]{
-padding-top: 2px;
-padding-bottom: 2px;
-padding-left: 6px;
-padding-right: 6px;
+background:#E3E1E1;
+padding: 6px;
 margin: 1px;
 border: 1px solid #8DCDEB;
 color:#8DCDEB;
-border-radius: 15px;
+border-radius: 3px;
 cursor: pointer;
 color:#1A1A1A;
+transition-duration:0.5s;
 }
 form .number {
 text-align:right;

--- a/css/wood/forms.css
+++ b/css/wood/forms.css
@@ -54,11 +54,20 @@ color:#1A1A1A;
 font-family:inherit;
 font-size:inherit;
 }
+form fieldset field select {
+background:url(images/descending.png) no-repeat right #FEFEBB;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
+}
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -93,19 +102,21 @@ background-size:14px 14px;
 padding-left:24px;
 }
 form input[type="submit"]{
-background:#D6D6D5;
+background:#FFD980;
 padding-top: 6px;
 padding-bottom: 6px;
 padding-left: 15px;
 padding-right: 15px;
-margin: 1px;
-border-left: 2px solid #DDDDDD;
-border-right: 2px solid #BFBFBF;
-border-bottom: 2px solid #BFBFBF;
-border-top: 2px solid #DDDDDD;
-border-radius: 3px;
+margin: 2px;
+margin-top:6px;
+border: 2px solid #824411;
+border-radius: 7px;
 cursor: pointer;
 color:#1A1A1A;
+}
+form input[type="submit"]:hover{
+background:#F8C03C;
+transition-duration:0.5s;
 }
 form input[type="submit"]:active{
 border-right: 2px solid #DDDDDD;
@@ -114,14 +125,15 @@ border-top: 2px solid #BFBFBF;
 border-bottom: 2px solid #DDDDDD;
 }
 form input[type="reset"]{
-padding-top: 2px;
-padding-bottom: 2px;
-padding-left: 6px;
-padding-right: 6px;
-margin: 1px;
-border: 1px solid #8DCDEB;
-color:#8DCDEB;
-border-radius: 15px;
+background:#FFD980;
+padding-top: 6px;
+padding-bottom: 6px;
+padding-left: 15px;
+padding-right: 15px;
+margin: 2px;
+margin-top:6px;
+border: 2px solid #824411;
+border-radius: 7px;
 cursor: pointer;
 color:#1A1A1A;
 }

--- a/css/xenos/forms.css
+++ b/css/xenos/forms.css
@@ -52,12 +52,22 @@ padding:2px;
 color:#1A1A1A;
 font-family:inherit;
 font-size:inherit;
+margin-right:3px;
+}
+form fieldset field select {
+background:url(images/descending.png) no-repeat right #e2f5ff;
+padding-right:24px;
+background-size:contain;
+-moz-appearance:none;
+-webkit-appearance: none;
 }
 form fieldset field input:hover,select:hover,textarea:hover {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input:focus,select:focus,textarea:focus {
 box-shadow: 0 0 3px #480FCE;
+transition-duration:0.5s;
 }
 form fieldset field input[type="email"] {
 display:inline;
@@ -108,16 +118,21 @@ cursor: pointer;
 color:#FFFFFF;
 }
 form input[type="reset"]{
-padding-top: 2px;
-padding-bottom: 2px;
-padding-left: 6px;
-padding-right: 6px;
+background:#34A7E8;
+font-weight:bold;
+padding-left: 16px;
+padding-right: 16px;
+padding-top:6px;
+padding-bottom:6px;
 margin: 1px;
-border: 1px solid #8DCDEB;
+margin-top:10px;
+margin-bottom:10px;
+border: 1px solid #0C374B;
 color:#8DCDEB;
-border-radius: 15px;
+border-radius: 6px;
 cursor: pointer;
-color:#1A1A1A;
+color:#FFFFFF;
+}
 }
 form .number {
 text-align:right;


### PR DESCRIPTION
Verwenden Sie Übergänge, wenn sich das Element beim Hover ändert
Die Schaltfläche "Reset" ähnelt der Schaltfläche "Submit"
Verwenden Sie einen neuen, eleganten Look, um die Dropdowns abzusenken

Files changed in commit:
css/aguapop/forms.css
css/arc-dark/forms.css
css/default/forms.css
css/fluid/forms.css
css/fresh/forms.css
css/gel/forms.css
css/mobile/forms.css
css/professional-rtl/forms.css
css/professional/forms.css
css/silverwolf/forms.css
css/wood/forms.css
css/xenos/forms.css
On branch develop